### PR TITLE
Fix the mysql configuration error in ConfigHandler.java

### DIFF
--- a/src/main/java/org/bruno/elytraEssentials/handlers/ConfigHandler.java
+++ b/src/main/java/org/bruno/elytraEssentials/handlers/ConfigHandler.java
@@ -133,7 +133,7 @@ public class ConfigHandler {
         this.host = this.fileConfiguration.getString("storage.mysql.host", "localhost");
         this.port = this.fileConfiguration.getInt("storage.mysql.port", 3306);
         this.database = this.fileConfiguration.getString("storage.mysql.database", "elytraessentials");
-        this.username = this.fileConfiguration.getString("storage.mysql.user", "root");
+        this.username = this.fileConfiguration.getString("storage.mysql.username", "root");
         this.password = this.fileConfiguration.getString("storage.mysql.password", "");
 
         this.isBoostEnabled = this.fileConfiguration.getBoolean("flight.boost.enabled", true);


### PR DESCRIPTION
Fix the mysql configuration error in `ConfigHandler.java`
`ConfigHandler.java` incorrectly gets `storage.mysql.username` from `config.yml`

https://github.com/bruno-medeiros1/elytra-essentials/blob/7309dafa48c71cbf2f0862e798c3fc1cd2622efc/src/main/java/org/bruno/elytraEssentials/handlers/ConfigHandler.java#L136
https://github.com/bruno-medeiros1/elytra-essentials/blob/7309dafa48c71cbf2f0862e798c3fc1cd2622efc/src/main/resources/config.yml#L87